### PR TITLE
WPE and WNT import protection

### DIFF
--- a/wrappers/python/wirepas_messaging/__init__.py
+++ b/wrappers/python/wirepas_messaging/__init__.py
@@ -2,5 +2,15 @@
 
 from . import gateway
 from . import nanopb
-from . import wpe
-from . import wnt
+
+try:
+    from . import wpe
+except ImportError:
+    print("Could not import WPE handles")
+    pass
+
+try:
+    from . import wnt
+except ImportError:
+    print("Could not import WPE handles")
+    pass

--- a/wrappers/python/wirepas_messaging/__init__.py
+++ b/wrappers/python/wirepas_messaging/__init__.py
@@ -7,10 +7,8 @@ try:
     from . import wpe
 except ImportError:
     print("Could not import WPE handles")
-    pass
 
 try:
     from . import wnt
 except ImportError:
     print("Could not import WPE handles")
-    pass


### PR DESCRIPTION
This commit adds a protection to the import statements of WPE
and WNT to allow a more relaxed set of dependencies.

With this change the protobuf package is the minimal requirement
to install.