### PR TITLE
Repo path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ script:
   - "./.ci/build.sh"
   - pip3 install wrappers/python/dist/*.whl
 
+before_deploy:
+  - cd wrappers/python
+
 deploy:
   - provider: pypi
     user: wirepas
@@ -29,9 +32,9 @@ deploy:
   - provider: releases
     api_key:
       secure: raSLK4E2IhWVsVj0RQ2VM1Fw/xPxFR4xiPRY+2DtU/4Pu7accMMVlO8eBjPH0GekVb0aTERfnh4fPTUG6T5fpQxLbawAnNJFkhvepZxH1EeClKvNvgthazEjlAdRMu1SfOpn/1+qKwyUx6tLbINPSwfM9Ait1uOZWJXJLnraQwubsF0lmW9LHoevwSV841grQG2wUI/oCi4bFSyQhXw6e/sU2alXigQ47YAXdgRyr3uAmj59F4AzTDVdFMLX8S6i5k+6xKRriqkHadmiGNEJHTK1qkR9bHDDIQR6nBFDXiV5UNNveS3q59xolPoAu9moljMODtR8t8CeIQ5dSlxjVZgMXE/qnuOmwMlXwQpTbYUux5m2XK5QWtz+PUFEFjdKMOdPkWHyUaBYWjdhk2z6aEHaKZjtzXhxbMyOds1U3vIeMhSnOvrH6OPFfgRL/KJuitY2gqyp4cRrH8lQr7PmcTCB+wjFhHBaEErHOp5y8775DW41ptFzYI1aavdnM4+2JGptRCDW6EMSt+pqVKdIZjpjmPK24VZPpTwo/mjBdYLEiR3HT+Ko5tzNDWdlHFFwK6JCgHIgCn5NWI13eVPq5mxCG+Ct6H4YJCpLTkwMT9U35r2UB1u8xBp5qNK7UInbjI6Vtt7PQqhPLDMZtYBlcOxjlpyZ4oOxu3dqj4QY3gc=
-    file: wrappers/python/dist/ TO UPLOAD
+    file: .dist/*
     skip_cleanup: true
-    draft: tag ~= /^v([0-9.]+)$rc([0-9]+)/
+    draft: tag ~= /^v([0-9.]+)$rc([0-9.]+)/
     on:
       tags: true
       branch: master


### PR DESCRIPTION
For the deploy to work, travis must be on the root
of the python package (where setup.py is located).

This commit cahnges to the correct repository path
before deploying.