### PR TITLE
Add protobuf package

### DIFF
--- a/wrappers/python/requirements.txt
+++ b/wrappers/python/requirements.txt
@@ -1,3 +1,5 @@
 # grpc
 grpcio==1.21.1
+protobuf==3.9.0
+
 


### PR DESCRIPTION
The grpcio package is missing the protobug package, hence it has to
be met separately.