### PR TITLE
Source package version from git

### DIFF
--- a/wrappers/python/.gitignore
+++ b/wrappers/python/.gitignore
@@ -9,3 +9,4 @@ wirepas_messaging/gateway/*pb2*.py
 
 Pipfile
 Pipfile.lock
+version.py

--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -23,6 +23,28 @@ with open(readme_file) as f:
     long_description = f.read()
 
 
+def custom_scheme():
+    def custom_version(version):
+        tag = str(version.tag)
+        if version.exact:
+            return tag
+
+        # split on rc and compute a pre-release tag for the next patch
+        tag_components = tag.rsplit("rc")
+        major, minor, patch = tag_components[0].split(".")
+        patch = int(patch) + 1
+        distance = version.distance
+        tag = f"{major}.{minor}.{patch}.dev{distance}"
+
+        return tag
+
+    return {
+        "root": "../..",
+        "version_scheme": custom_version,
+        "local_scheme": "no-local-version",
+    }
+
+
 def get_list_files(root, flist=None):
     if flist is None:
         flist = list()
@@ -58,7 +80,8 @@ with open(get_absolute_path("./wirepas_messaging/__about__.py")) as f:
 
 setup(
     name=about["__pkg_name__"],
-    version=about["__version__"],
+    use_scm_version=custom_scheme,
+    setup_requires=["setuptools_scm"],
     description=about["__description__"],
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -42,6 +42,8 @@ def custom_scheme():
         "root": "../..",
         "version_scheme": custom_version,
         "local_scheme": "no-local-version",
+        "write_to": "wrappers/python/version.py",
+        "fallback_version": str(fallback_version["version"]),
     }
 
 
@@ -77,6 +79,14 @@ def get_requirements(*args):
 about = {}
 with open(get_absolute_path("./wirepas_messaging/__about__.py")) as f:
     exec(f.read(), about)
+
+fallback_version = {}
+try:
+    with open(get_absolute_path("./version.py")) as f:
+        exec(f.read(), fallback_version)
+except FileNotFoundError:
+    fallback_version["version"] = "0.1.0"
+
 
 setup(
     name=about["__pkg_name__"],

--- a/wrappers/python/wirepas_messaging/__about__.py
+++ b/wrappers/python/wirepas_messaging/__about__.py
@@ -4,6 +4,8 @@
         See file LICENSE for full license details.
 """
 
+from pkg_resources import get_distribution, DistributionNotFound
+
 __author__ = "Wirepas Ltd"
 __author_email__ = "opensource@wirepas.com"
 __classifiers__ = [
@@ -20,7 +22,6 @@ __license__ = "Apache-2"
 __pkg_name__ = "wirepas_messaging"
 __title__ = "Wirepas Messaging Wrappers"
 __url__ = "https://github.com/wirepas/backend-apis/tree/master/wrappers/python"
-__version__ = "1.4.0"
 __warning_msg__ = """
 ***********************************************************************
 * WARNING:
@@ -30,3 +31,9 @@ __warning_msg__ = """
 *     https://github.com/protocolbuffers/protobuf/tree/master/python
 ***********************************************************************
 """
+
+try:
+    __version__ = get_distribution(__pkg_name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass


### PR DESCRIPTION
This change relies on setuptools scm to retrive the python
package number.

With this change, each merge on master can be safely pushed to
PyPi to ease up distribution and test of next releases.

To obtain the package's version, tyep:

python setup.py --version