### PR TITLE
Add network address to PacketReceivedEvent

### DIFF
--- a/gateway_to_backend/protocol_buffers_files/data_message.proto
+++ b/gateway_to_backend/protocol_buffers_files/data_message.proto
@@ -47,4 +47,5 @@ message PacketReceivedEvent {
     optional uint32 payload_size = 10;
 
     optional uint32 hop_count = 11;
+    optional uint64 network_address = 12;
 }


### PR DESCRIPTION
This information is not part of a message received from Wirepas Network but the gateway knows it from the received sink.
It is required in the MQTT topic and that is the only info that is in MQTT part and not in protobuf.
Setting it may help backends as they not necessarily need to keep an association table from gateway_id/sink_id to network_id