### PR TITLE
Updating the protobuf messages to handle request on the gateway status

### DIFF
--- a/gateway_to_backend/README.md
+++ b/gateway_to_backend/README.md
@@ -277,6 +277,24 @@ _Even if this version is increased, the API remains backward compatible.
 It just help backends development to identify if new features are
 present in a gateway._
 
+#### Get gateway status
+
+- **Request:**
+
+    > **topic:** gw-request/get_gw_status
+    >
+    > **content:** NA
+
+- **Response:**
+
+    > **topics:** gw-response/get_gw_status/*\<gw-id\>/\<sink-id\>*
+    >
+    > **content:** [GenericMessage][message_GenericMessage].[WirepasMessage][message_WirepasMessage].[GetGwInfoResp][message_GetGwInfoResp]
+
+This request should be handled by Gateways only if retain flag is not supported.
+When receiving a message on this topic, a gateway must resend its status as described
+in [Status message](#status_message)
+
 ### Data module
 
 ---
@@ -518,6 +536,7 @@ definition)
 
     gw-request/otap_set_target_scratchpad/<gw-id>/<sink-id>
 
+    gw-request/get_gw_status
 ```
 
 *Response* from a gateway to a backend:
@@ -538,6 +557,8 @@ definition)
     gw-response/otap_process_scratchpad/<gw-id>/<sink-id>
 
     gw-response/otap_set_target_scratchpad/<gw-id>/<sink-id>
+
+    gw-response/get_gw_status/<gw-id>/<sink-id>
 ```
 
 *Asynchronous* event from a gateway:

--- a/gateway_to_backend/protocol_buffers_files/config_message.proto
+++ b/gateway_to_backend/protocol_buffers_files/config_message.proto
@@ -107,6 +107,16 @@ message GatewayInfo {
     optional uint32 implemented_api_version = 4;
 }
 
+message GatewayStatus {
+    // Wirepas Gateway's protobuff message definition version
+    // This field is used to represent the version of the 
+    // protobuff messages as a whole implemented by the 
+    // gateway. Any breaking change in the message definition 
+    // must lead to an increment of the version's value reported
+    required uint32 version = 2;
+    required OnOffState state = 3;
+}
+
 /*
  * Commands definition
  */
@@ -153,4 +163,14 @@ message GetGwInfoResp {
     required ResponseHeader header = 1;
 
     required GatewayInfo info = 2;
+}
+
+message GetGwStatusReq {
+    required RequestHeader header = 1;
+}
+
+message GetGwStatusResp {
+    required ResponseHeader header = 1;
+
+    required GatewayStatus status = 2;
 }

--- a/gateway_to_backend/protocol_buffers_files/generic_message.proto
+++ b/gateway_to_backend/protocol_buffers_files/generic_message.proto
@@ -25,6 +25,8 @@ message WirepasMessage {
     optional GetGwInfoResp get_gateway_info_resp = 16;
     optional SetScratchpadTargetAndActionReq set_scratchpad_target_and_action_req = 17;
     optional SetScratchpadTargetAndActionResp set_scratchpad_target_and_action_resp = 18;
+    optional GetGwStatusReq get_gateway_status_req = 19;
+    optional GetGwStatusResp get_gateway_status_resp = 20;
 }
 
 message CustomerMessage {


### PR DESCRIPTION
Adding Gateways status request and response protobuf messages. This can be used in the case where the mqtt broker does not support retained message and we would like to know the status of the gateways as soon as possible.

The concerned topics in the mqtt broker would be:
gw-request/get_gw_status
gw-response/get_gw_status/<gw-id>/<sink-id>