### PR TITLE
Fix README on otap_load_scratchpad response topic

### DIFF
--- a/gateway_to_backend/README.md
+++ b/gateway_to_backend/README.md
@@ -357,7 +357,7 @@ _Consequently, it is highly recommended to keep this field._
 
 - **Response:**
 
-    > **topics:** gw-response/otap_status/*\<gw-id\>/\<sink-id\>*
+    > **topics:** gw-response/otap_load_scratchpad/*\<gw-id\>/\<sink-id\>*
     >
     > **content:** [GenericMessage][message_GenericMessage].[WirepasMessage][message_WirepasMessage].[UploadScratchpadResp][message_UploadScratchpadResp]
 


### PR DESCRIPTION
Fixes wrong response topic on `upload local scratchpad`.

Correctly as in the end:

```
*Response* from a gateway to a backend:
...
gw-response/otap_load_scratchpad/<gw-id>/<sink-id>
```