### PR TITLE
Gateway Api: Extend Gateway status

### DIFF
--- a/gateway_to_backend/protocol_buffers_files/config_message.proto
+++ b/gateway_to_backend/protocol_buffers_files/config_message.proto
@@ -65,6 +65,14 @@ message SinkReadConfig {
 
     // State of sink
     optional OnOffState sink_state = 17;
+
+    // Scratchpad info for the sink
+    optional ScratchpadInfo stored_scratchpad = 18;
+    optional ScratchpadStatus stored_status = 19;
+    optional ScratchpadType stored_type = 20;
+    optional ScratchpadInfo processed_scratchpad = 21;
+    optional uint32 firmware_area_id = 22;
+    optional TargetScratchpadAndAction target_and_action = 23; // Unset if sink doesn't support it
 }
 
 message SinkNewConfig {
@@ -120,6 +128,16 @@ message GatewayInfo {
     // must lead to an increment of the version's value reported
     required uint32 version = 2;
     required OnOffState state = 3;
+
+    // Current Gateway config in the status to avoid client asking for it
+    // Each time config is changed on a gateway, this status must be updated
+    repeated SinkReadConfig configs = 4;
+
+    // Optional gateway name (gateway manufacturer specific)
+    optional string gw_model = 5;
+
+    // Optional gateway version (gateway manufacturer specific)
+    optional string gw_version = 6;
 }
 
 message GetConfigsReq {

--- a/gateway_to_backend/protocol_buffers_files/otap_message.proto
+++ b/gateway_to_backend/protocol_buffers_files/otap_message.proto
@@ -6,61 +6,6 @@ import "wp_global.proto";
 import "error.proto";
 // import "nanopb.proto";
 
-enum ScratchpadType {
-    BLANK = 1;
-    PRESENT = 2;
-    PROCESS = 3;
-}
-
-enum ScratchpadStatus {
-    SUCCESS = 1;
-    NEW = 2;
-    ERROR = 3;
-}
-
-enum ScratchpadAction {
-    // Will be the default value in case it is later extended
-    UNKNOWN_ACTION = 0;
-    // No propagation, no processing of scratchpad
-    NO_OTAP = 1;
-    // Propagate the target scratchpad but no processing
-    PROPAGATE_ONLY = 2;
-    // Propagate the target scratchpad and process it as soon as received
-    PROPAGATE_AND_PROCESS = 3;
-    // Propagate the target scratchpad and process it after delay (starting when scratchpad is present and this info received)
-    PROPAGATE_AND_PROCESS_WITH_DELAY = 4;
-    // Otap propagation works as before with sequence comparison and processing through remote API
-    LEGACY_OTAP = 5;
-}
-
-enum ProcessingDelay {
-    UNKNOWN_DELAY = 0;
-    TEN_MINUTES = 1;
-    THIRTY_MINUTES = 2;
-    ONE_HOUR = 3;
-    SIX_HOURS = 4;
-    ONE_DAY = 5;
-    TWO_DAYS = 6;
-    FIVE_DAYS = 7;
-}
-
-
-message ScratchpadInfo {
-    required uint32 len = 1;
-    required uint32 crc = 2;
-    required uint32 seq = 3;
-}
-
-message TargetScratchpadAndAction {
-    required ScratchpadAction action = 1; // What is the action to perform with the current scratchpad
-    optional uint32 target_sequence = 2; // Between 1 and 254 (if missing using local scratchpad sequence if present)
-    optional uint32 target_crc = 3; // Between 0 and 0xffff (if missing using local scratchpad CRC if present)
-    oneof param {
-       ProcessingDelay delay = 4; // Delay parameter for action PROPAGATE_AND_PROCESS_WITH_DELAY
-       uint32 raw = 5; // Raw parameter for the action (between 0 and 255)
-    }
-}
-
 /*
  * Request/Responses definition
  */

--- a/gateway_to_backend/protocol_buffers_files/wp_global.proto
+++ b/gateway_to_backend/protocol_buffers_files/wp_global.proto
@@ -51,3 +51,57 @@ message FirmwareVersion {
     required uint32 maint = 3;
     required uint32 dev = 4;
 }
+
+enum ScratchpadType {
+    BLANK = 1;
+    PRESENT = 2;
+    PROCESS = 3;
+}
+
+enum ScratchpadStatus {
+    SUCCESS = 1;
+    NEW = 2;
+    ERROR = 3;
+}
+
+enum ScratchpadAction {
+    // Will be the default value in case it is later extended
+    UNKNOWN_ACTION = 0;
+    // No propagation, no processing of scratchpad
+    NO_OTAP = 1;
+    // Propagate the target scratchpad but no processing
+    PROPAGATE_ONLY = 2;
+    // Propagate the target scratchpad and process it as soon as received
+    PROPAGATE_AND_PROCESS = 3;
+    // Propagate the target scratchpad and process it after delay (starting when scratchpad is present and this info received)
+    PROPAGATE_AND_PROCESS_WITH_DELAY = 4;
+    // Otap propagation works as before with sequence comparison and processing through remote API
+    LEGACY_OTAP = 5;
+}
+
+enum ProcessingDelay {
+    UNKNOWN_DELAY = 0;
+    TEN_MINUTES = 1;
+    THIRTY_MINUTES = 2;
+    ONE_HOUR = 3;
+    SIX_HOURS = 4;
+    ONE_DAY = 5;
+    TWO_DAYS = 6;
+    FIVE_DAYS = 7;
+}
+
+message ScratchpadInfo {
+    required uint32 len = 1;
+    required uint32 crc = 2;
+    required uint32 seq = 3;
+}
+
+message TargetScratchpadAndAction {
+    required ScratchpadAction action = 1; // What is the action to perform with the current scratchpad
+    optional uint32 target_sequence = 2; // Between 1 and 254 (if missing using local scratchpad sequence if present)
+    optional uint32 target_crc = 3; // Between 0 and 0xffff (if missing using local scratchpad CRC if present)
+    oneof param {
+       ProcessingDelay delay = 4; // Delay parameter for action PROPAGATE_AND_PROCESS_WITH_DELAY
+       uint32 raw = 5; // Raw parameter for the action (between 0 and 255)
+    }
+}


### PR DESCRIPTION
Idea of this extension is to avoid querry from backendS to every gateway. By subscribing to status topic (either as retain topic or periodic) a backend will have an exact vision of the network without the need to explicitly ask for the config.

Of course it is still possible to explicity asked the config, for older gateways or gateway that wouldn't implement it (our reference gw will populate it).

The only downside is that status message will be a bit bigger, but it shouldn't be a problem