### PR TITLE
Scratchpad as chunk

### DIFF
--- a/gateway_to_backend/protocol_buffers_files/config_message.proto
+++ b/gateway_to_backend/protocol_buffers_files/config_message.proto
@@ -112,6 +112,12 @@ message GatewayInfo {
     // Version 2: Addition of setScratchpadTargetAndAction
     // It should be replaced by a feature list
     optional uint32 implemented_api_version = 4;
+
+    // Maximun scratchpad size supported by gateway
+    // If scratchpad is bigger than the size specified,
+    // it must be sent as chunk. If not set, it means that
+    // scratchpad can be sent in a single request
+    optional uint32 max_scratchpad_size = 5;
 }
 
 /*
@@ -137,6 +143,9 @@ message GatewayInfo {
 
     // Optional gateway version (gateway manufacturer specific)
     optional string gw_version = 6;
+
+    // See GatewayInfo for details of this field
+    optional uint32 max_scratchpad_size = 7;
 }
 
 message GetConfigsReq {

--- a/gateway_to_backend/protocol_buffers_files/error.proto
+++ b/gateway_to_backend/protocol_buffers_files/error.proto
@@ -43,7 +43,7 @@ enum ErrorCode {
     INVALID_MAX_HOP_COUNT = 25;
     SINK_OUT_OF_MEMORY = 26;
     SINK_TIMEOUT = 27;
-    INVALID_SCRATCHPAD_CHUNK_ID = 28;
+    INVALID_SCRATCHPAD_CHUNK_OFFSET = 28;
     // If scratchpad chunk size is bigger than
     // the max value supported by the gateway
     INVALID_SCRATCHPAD_CHUNK_SIZE = 29;

--- a/gateway_to_backend/protocol_buffers_files/error.proto
+++ b/gateway_to_backend/protocol_buffers_files/error.proto
@@ -43,4 +43,8 @@ enum ErrorCode {
     INVALID_MAX_HOP_COUNT = 25;
     SINK_OUT_OF_MEMORY = 26;
     SINK_TIMEOUT = 27;
+    INVALID_SCRATCHPAD_CHUNK_ID = 28;
+    // If scratchpad chunk size is bigger than
+    // the max value supported by the gateway
+    INVALID_SCRATCHPAD_CHUNK_SIZE = 29;
 }

--- a/gateway_to_backend/protocol_buffers_files/otap_message.proto
+++ b/gateway_to_backend/protocol_buffers_files/otap_message.proto
@@ -24,11 +24,23 @@ message GetScratchpadStatusResp {
 }
 
 message UploadScratchpadReq {
+    message ChunkInfo {
+        // Id of the scratchpad this chunk belongs to
+        required uint32 scratchpad_unique_id = 1;
+        // Full size of the scratchpad this chunk belongs to
+        required uint32 scratchpad_full_size = 2;
+        // Offset in bytes of the chunk in the full scratchpad
+        // NB: Chunk must be sent in order
+        required uint32 start_offset = 3;
+    }
     required RequestHeader header = 1;
 
     required uint32 seq = 2;
     // If scratchpad is not set, it clears the stored scratchpad
     optional bytes scratchpad = 3;
+
+    // If ChunkInfo is present, then above scratchpad is a chunk
+    optional ChunkInfo chunk_info = 4;
 }
 
 message UploadScratchpadResp {

--- a/gateway_to_backend/protocol_buffers_files/otap_message.proto
+++ b/gateway_to_backend/protocol_buffers_files/otap_message.proto
@@ -25,13 +25,11 @@ message GetScratchpadStatusResp {
 
 message UploadScratchpadReq {
     message ChunkInfo {
-        // Id of the scratchpad this chunk belongs to
-        required uint32 scratchpad_unique_id = 1;
         // Full size of the scratchpad this chunk belongs to
-        required uint32 scratchpad_full_size = 2;
+        required uint32 scratchpad_total_size = 1;
         // Offset in bytes of the chunk in the full scratchpad
         // NB: Chunk must be sent in order
-        required uint32 start_offset = 3;
+        required uint32 start_offset = 2;
     }
     required RequestHeader header = 1;
 


### PR DESCRIPTION
Add a backward compatible way to upload a scratchpad per chunk in case gateway do not support a full scratchpad transfer